### PR TITLE
fix: upgraded sipp version and fix dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:bullseye-slim AS compile
-ARG SIPP_VERSION="3.6.1"
+ARG SIPP_VERSION="3.7.7"
 
 WORKDIR /sipp
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential cmake wget libssl-dev libpcap-dev libsctp-dev libncurses5-dev && \
+    apt-get install -y --no-install-recommends build-essential cmake wget libssl-dev libpcap-dev libsctp-dev libncurses5-dev libgsl-dev && \
     wget --no-check-certificate "https://github.com/SIPp/sipp/releases/download/v$SIPP_VERSION/sipp-$SIPP_VERSION.tar.gz" && \
     tar -xzf sipp-$SIPP_VERSION.tar.gz -C . && \
     cd sipp-$SIPP_VERSION && \
@@ -11,10 +11,10 @@ RUN apt-get update && \
 
 FROM debian:bullseye-slim AS sipp
 
-ARG SIPP_VERSION="3.6.1"
+ARG SIPP_VERSION="3.7.7"
 
 
-RUN apt-get update && apt-get install -y --no-install-recommends libncurses5 libncursesw6 libpcap0.8 libsctp1
+RUN apt-get update && apt-get install -y --no-install-recommends libncurses5 libncursesw6 libpcap0.8 libsctp1 libgsl25
 
 WORKDIR /sipp
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker container for SIPp
 
 - Docker container for running [SIPp](http://sipp.sourceforge.net/index.html)
-- Builds version 3.6.1 from [Github ](https://github.com/SIPp)
+- Builds version 3.7.7 from [Github ](https://github.com/SIPp)
 - [Github Repo](https://github.com/ctaloi/docker-sipp)
 - [Docker Hub](https://hub.docker.com/r/ctaloi/sipp/)
 


### PR DESCRIPTION
Updated SIPP version bumped to 3.7.7 latest release.
It was detected an extra dependency required to build the newer version, so it was added.

Maintenance PR